### PR TITLE
Update to rstan 2.17.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: torstenHeaders
 Type: Package
 Title: Torsten library extension for 'rstan'
 Version: 0.1.0
-Date: 2017-09-11
+Date: 2018-01-16
 Maintainer: The package maintainer <billg@metrumrg.com>
 Authors@R: c(person("Jonathan", "Sidi", email = "yonis@metrumrg.com", role = c("aut", "cre")),
              person("Bill", "Gillespie", email = "billg@metrumrg.com", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: torstenHeaders
 Type: Package
 Title: Torsten library extension for 'rstan'
-Version: 0.1.0
+Version: 0.1.1
 Date: 2018-01-16
 Maintainer: The package maintainer <billg@metrumrg.com>
 Authors@R: c(person("Jonathan", "Sidi", email = "yonis@metrumrg.com", role = c("aut", "cre")),

--- a/R/install_torsten.R
+++ b/R/install_torsten.R
@@ -1,3 +1,4 @@
+
 #' @title Installation for torsten
 #' @description installation of torsten with rstan, that replaces stanHeaders.
 #' @param StanHeaders_version package_version, package version of StanHeaders to append Torsten Default: NULL
@@ -15,11 +16,11 @@ install_torsten <- function(StanHeaders_version=NULL,
                             rstan_version=NULL,
                             lib=.libPaths()[1],
                             ...) {
-  
+
   lib <- normalizePath(lib,winslash = '/')
-  
+
   install_headers <- FALSE
-  
+
   if(is.null(StanHeaders_version)){
     if(c('StanHeaders')%in%row.names(utils::installed.packages(lib.loc = lib))){
       StanHeaders_version <- utils::packageVersion('StanHeaders',lib.loc = lib)
@@ -29,7 +30,7 @@ install_torsten <- function(StanHeaders_version=NULL,
       install_headers <- TRUE
     }
   }
-  
+
   if(install_headers){
     if(pkgVersionCRAN('StanHeaders')==StanHeaders_version){
       utils::install.packages('StanHeaders', lib=lib, ...)
@@ -37,23 +38,23 @@ install_torsten <- function(StanHeaders_version=NULL,
       devtools::install_version(package = 'StanHeaders',version = StanHeaders_version,lib=lib, ...)
     }
   }
-  
-  
+
+
   TH <- find.package('torstenHeaders')
-  
-  file.copy(file.path(TH,'stan'),file.path(lib,'StanHeaders/include/src'),overwrite=TRUE,recursive=TRUE)
-  file.copy(file.path(TH,'/math/stan'),file.path(lib,'StanHeaders/include'),overwrite=TRUE,recursive=TRUE)
-  
+
+  file.copy(file.path(TH,'stan'),file.path(lib,'StanHeaders/include/src/'),overwrite=TRUE,recursive=TRUE)
+  file.copy(file.path(TH,'math/stan'),file.path(lib,'StanHeaders/include/'),overwrite=TRUE,recursive=TRUE)
+
   if(is.null(rstan_version)) rstan_version <- read.dcf(system.file('CURRENT_VERSION',package = 'torstenHeaders'),fields = 'rstan')
-  
+
   rstan_version <- as.package_version(rstan_version)
-  
+
   if(pkgVersionCRAN('rstan')==rstan_version){
     utils::install.packages('rstan', lib=lib, type='source', ...)
   }else{
     devtools::install_version(package = 'rstan', version = rstan_version, lib=lib, type='source', ...)
   }
-  
-  
-  
+
+
+
 }

--- a/R/install_torsten_remote.R
+++ b/R/install_torsten_remote.R
@@ -60,10 +60,10 @@ install_torsten_remote <- function(
     }
 
     system(sprintf("rm -rf %s/StanHeaders/include/src/stan",lib))
-    system(sprintf("mv %s/stan/src/stan %s/StanHeaders/include/src/stan",td,lib))
+    system(sprintf("mv %s/stan/src/stan %s/StanHeaders/include/src/",td,lib))
 
     system(sprintf("rm -rf %s/StanHeaders/include/stan",lib))
-    system(sprintf("mv %s/math/stan %s/StanHeaders/include/stan",td,lib))
+    system(sprintf("mv %s/math/stan %s/StanHeaders/include/",td,lib))
 
   if(is.null(rstan_version)) rstan_version <- read.dcf(system.file('CURRENT_VERSION',package = 'torstenHeaders'),fields = 'rstan')
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,18 +11,18 @@
   getURLS <- xml2::read_html('https://github.com/metrumresearchgroup/TorstenHeaders/tree/master/inst')%>%
     rvest::html_nodes(xpath = '//*[contains(concat( " ", @class, " " ), concat( " ", "css-truncate-target", " " ))]//span//a')%>%
     rvest::html_attr(name = 'href')
-  
+
   getURLS <- sprintf('https://github.com%s.zip',gsub('tree','archive',getURLS))
-  
+
   names(getURLS) <- sapply(strsplit(getURLS,'/'),'[',5)
-  
+
   zipnames <- sapply(names(getURLS),function(x) paste(x,tools::file_path_sans_ext(basename(getURLS[x])),sep='-'))
-  
+
   if(length(list.files(file.path(TH,'stan')))==0){
-    
+
     utils::download.file(url = getURLS['stan'],destfile = file.path(td,'/stan.zip'),quiet = TRUE)
     utils::unzip(file.path(td,'stan.zip'),exdir = td)
-    
+
     file.copy(file.path(td,zipnames['stan'],'src/stan'),
               TH,
               overwrite = TRUE,
@@ -30,15 +30,16 @@
   }
 
   if(length(list.files(file.path(TH,'math')))==0){
-    
+
     download.file(url = getURLS['math'],destfile = file.path(td,'/math.zip'),quiet = TRUE)
     utils::unzip(file.path(td,'math.zip'),exdir = td)
-    
+
     suppressWarnings({
+      dir.create(file.path(TH,'math'))
       file.copy(file.path(td,zipnames['math'],'stan'),
                 file.path(TH,'math'),
                 overwrite = TRUE,
-                recursive = TRUE)  
+                recursive = TRUE)
     })
 
   }
@@ -52,47 +53,47 @@
 #' @importFrom utils unzip download.file
 #' @importFrom tools file_path_sans_ext
 .onAttach <- function(libname, pkgname) {
-  
+
   td <- file.path(tempdir(),'torsten')
   dir.create(td,showWarnings = FALSE)
   TH <- find.package('torstenHeaders')
-  
+
   getURLS <- xml2::read_html('https://github.com/metrumresearchgroup/TorstenHeaders/tree/master/inst')%>%
     rvest::html_nodes(xpath = '//*[contains(concat( " ", @class, " " ), concat( " ", "css-truncate-target", " " ))]//span//a')%>%
     rvest::html_attr(name = 'href')
-  
+
   getURLS <- sprintf('https://github.com%s.zip',gsub('tree','archive',getURLS))
-  
+
   names(getURLS) <- sapply(strsplit(getURLS,'/'),'[',5)
-  
+
   zipnames <- sapply(names(getURLS),function(x) paste(x,tools::file_path_sans_ext(basename(getURLS[x])),sep='-'))
-  
+
   if(length(list.files(file.path(TH,'stan')))==0){
-    
+
     utils::download.file(url = getURLS['stan'],destfile = file.path(td,'/stan.zip'),quiet = TRUE)
     utils::unzip(file.path(td,'stan.zip'),exdir = td)
-    
+
     file.copy(file.path(td,zipnames['stan'],'src/stan'),
               TH,
               overwrite = TRUE,
               recursive = TRUE)
   }
-  
+
   if(length(list.files(file.path(TH,'math')))==0){
-    
+
     download.file(url = getURLS['math'],destfile = file.path(td,'/math.zip'),quiet = TRUE)
     utils::unzip(file.path(td,'math.zip'),exdir = td)
-    
+
     suppressWarnings({
       file.copy(file.path(td,zipnames['math'],'stan'),
                 file.path(TH,'math'),
                 overwrite = TRUE,
-                recursive = TRUE)  
+                recursive = TRUE)
     })
-    
-    
+
+
   }
-  
+
   unlink(file.path(td,zipnames['math']),recursive = TRUE,force=TRUE)
   unlink(file.path(td,zipnames['stan']),recursive = TRUE,force=TRUE)
 }

--- a/inst/CURRENT_VERSION
+++ b/inst/CURRENT_VERSION
@@ -1,2 +1,2 @@
-StanHeaders: 2.16.0-1
-rstan: 2.16.2
+StanHeaders: 2.17.1
+rstan: 2.17.2


### PR DESCRIPTION
This is part of effort to bring torsten to stan 2.17.1. The corresponding rstan version is 2.17.2. The changes are on the version of stan/math libraries to retrieve, as well as copy path (the original file.copy part in install_torsten() does not work for me). 